### PR TITLE
initialize chromeOptions

### DIFF
--- a/src/Browser/BrowserDriverBuilder.php
+++ b/src/Browser/BrowserDriverBuilder.php
@@ -62,6 +62,7 @@ class BrowserDriverBuilder
         $this->url = $url;
         $this->extraCapabilities = [];
         $this->urls = [];
+        $this->chromeOptions = [];
     }
 
     public function __destruct()


### PR DESCRIPTION
Initialize chromeOptions in BrowserDriverBuilder that returns an error when creating a new browser with type chrome.

Related with issue #3 