### PR TITLE
fix error when reusing Browser instance after cleanup

### DIFF
--- a/src/Browser/Browser.php
+++ b/src/Browser/Browser.php
@@ -385,7 +385,6 @@ class Browser implements BrowserInterface
         $this->sessionCookie        = null;
         $this->remoteWebDriver      = null;
         $this->urlTranslator        = null;
-        $this->remoteDriverBuilder  = null;
     }
 
     /**


### PR DESCRIPTION
Browser->reset() was assigning null to remoteDriverBuilder, generating an error when reusing the browser instance.
I've added a test case and fixed the problem.